### PR TITLE
検索数列を複数指定できるようにする

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,4 @@ piget.sh piget.sh [from <Start search offset>] <Number string to search for>
 ## History
 * 2023.10.23
   - コマンド引数に「検索開始オフセット（from）」を追加する
+  - 検索数列を複数指定できるようにする

--- a/piget.sh
+++ b/piget.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 usage () {
-    echo "Usage: piget.sh [from <Start search offset>] <Number string to search for>";
+    echo "Usage: piget.sh [from <Start search offset>] <Number string to search for> ...";
     echo "<Start search offset> : Default is 0";
     exit 1;
 }
@@ -11,7 +11,7 @@ if [ $# -eq 0 ]; then
 fi
 
 strhr=0;
-lookfor="";
+lookfor=();
 while [ "$1" != "" ]; do
     #echo arg: $1;
     if [ "$1" == "from" ]; then
@@ -21,7 +21,7 @@ while [ "$1" != "" ]; do
         shift;
         strhr=$1;
     else
-        lookfor=$1;
+        lookfor+=("$1");
     fi
     shift;
 done
@@ -32,19 +32,38 @@ if [ ${#lookfor} -gt $blksize ]; then
     exit 1;
 fi
 
-dlt=${#lookfor}
+#echo Lookfor: ${lookfor[@]}
+maxprmlen=0;
+lookgors="";
+for prm in ${lookfor[@]}
+do {
+    prmlen=${#prm};
+    if [ $prmlen -gt $maxprmlen ]; then
+        maxprmlen=$prmlen;
+    fi
+    lookgors="$lookgors -e $prm"
+} done
+
+#echo - $lookgors
+#exit 1;
+
+#dlt=${#lookfor}
+dlt=$maxprmlen
 dlt=$((dlt - 1))
 rdoffset=$((blksize - dlt))
 
-#echo "Searching for $lookfor from $strhr";
+echo "Searching for ${lookgors[@]} from $strhr offset with $rdoffset offset";
 #exit 1;
 
 while true;  
 do { 
-    rtn=`curl https://api.pi.delivery/v1/pi?start=$strhr\&numberOfDigits=1000\&radix=10 2> /dev/null | grep $lookfor 2> /dev/null`; 
+    #rtn=`curl https://api.pi.delivery/v1/pi?start=$strhr\&numberOfDigits=1000\&radix=10 2> /dev/null | grep $lookfor 2> /dev/null`; 
+    rtn=`curl https://api.pi.delivery/v1/pi?start=$strhr\&numberOfDigits=1000\&radix=10 2> /dev/null | grep $lookgors 2> /dev/null`; 
     if [ ${#rtn} -eq 0 ]; 
-    then echo -en [$lookfor]$strhr :"\x0d";
-    else echo [$lookfor]$strhr :$rtn | grep --color $lookfor;
+    #then echo -en [$lookfor]$strhr :"\x0d";
+    #else echo [$lookfor]$strhr :$rtn | grep --color $lookfor;
+    then echo -en [${lookfor[@]}]$strhr :"\x0d";
+    else echo [${lookfor[@]}]$strhr :$rtn | grep --color $lookgors;
     fi;
     
     strhr=$((strhr + rdoffset));


### PR DESCRIPTION
検索数値格納変数を配列にし、そこから格納された数値列毎に "-e" を添付した grep への引数文字列を作成していく。
